### PR TITLE
Added threshold for compute_beam_ratio

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -23,7 +23,7 @@
 
 project(
     'skytools',
-    version: '0.0.1.b2',
+    version: '0.0.1.b3',
     meson_version: '>=0.63.0',
     default_options: [
       # The default can yield broken results.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ requires = ['meson-python']
 
 [project]
 name = 'skytools'
-version = '0.0.1.b2'
+version = '0.0.1.b3'
 description = 'A library of useful tools for CMB data analysis.'
 readme = 'README.md'
 requires-python = '>=3.9'

--- a/skytools/hpx_utils.py
+++ b/skytools/hpx_utils.py
@@ -52,7 +52,7 @@ def apodized_gauss_beam(fwhm, lmax):
     
     return Bl_apo
 
-def compute_beam_ratio(beam_nu, beam_0):
+def compute_beam_ratio(beam_nu, beam_0, thresh=0.):
     """
     Computes beam ratio to change the resolution/beam smoothing of a single map/alm.
 
@@ -78,8 +78,7 @@ def compute_beam_ratio(beam_nu, beam_0):
 
     ratio_nu = np.zeros((lmax_beam))
 
-    lmax_nonzero = np.max(np.where(beam_nu>0.))+1
-    # print(lmax_nonzero)
+    lmax_nonzero = np.max(np.where(beam_nu>thresh))+1
     ratio_nu[0:lmax_nonzero] = beam_0[0:lmax_nonzero] / beam_nu[0:lmax_nonzero]
 
     del lmax_beam, lmax_nonzero, beam_nu, beam_0


### PR DESCRIPTION
Added parameter `thresh` that sets the lmax value for the beam that goes in the denominator of the beam ratio. Useful for large beams at high ells to avoid the ratio from blowing up.