### PR TITLE
Saturate_mask function added

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -23,7 +23,7 @@
 
 project(
     'skytools',
-    version: '0.0.1.b3',
+    version: '0.0.1.b4',
     meson_version: '>=0.63.0',
     default_options: [
       # The default can yield broken results.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ requires = ['meson-python']
 
 [project]
 name = 'skytools'
-version = '0.0.1.b3'
+version = '0.0.1.b4'
 description = 'A library of useful tools for CMB data analysis.'
 readme = 'README.md'
 requires-python = '>=3.9'

--- a/skytools/mask_recipes.py
+++ b/skytools/mask_recipes.py
@@ -166,3 +166,9 @@ def intensity_mask(nside, IorP_map, percent_masked, smooth_in_deg=None, percent_
     
     return mask
 
+def saturate_mask(mask_in, clip_val):
+    saturated_mask = np.copy(mask_in)
+    saturated_mask[saturated_mask >= clip_val] = 1.
+    saturated_mask[saturated_mask < clip_val] = saturated_mask[saturated_mask < clip_val] / clip_val
+
+    return saturated_mask


### PR DESCRIPTION
Added new function saturate_mask to saturate hitcount-weighted or inverse noise variance-weighted masks. The output mask will be 1 above a certain threshold, with smooth transition as values are smaller than the threshold.